### PR TITLE
Setup registry and metrics only once and satisfy `govulncheck`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ tags
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/go,vim,visualstudiocode,macos,linux
+/homewizard-p1-exporter

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/kradalby/homewizard-p1-exporter
 
-go 1.21.4
+go 1.21.12
 
 require (
-	github.com/google/go-cmp v0.6.0
 	github.com/prometheus/client_golang v1.18.0
 	tailscale.com v1.56.1
 )
@@ -11,6 +10,7 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect


### PR DESCRIPTION
Hi @kradalby ,

I've moved the initialization of the metrics and the prometheus.Registry to `init()` so this is not called every scrape. Also i've bumped the go version in `go.mod` to satisfy [govulncheck](https://go.dev/blog/govulncheck).

Cheers!

note: for security reasons i've disabled "Allow edits by maintainers".

